### PR TITLE
shouldn't it be .del instead of .delete?

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ const docstore = await Database.DocStore([address])
   * Returns key of added value
 * `docstore.update(key:string, value:Object):Promise<void>`
   * Updates value in docstore
-* `docstore.delete(key:string):Promise<void>`
+* `docstore.del(key:string):Promise<void>`
   * Deletes value from docstore
 #### **KeyValue**:
 ```


### PR DESCRIPTION
Tried running both and doctsore.del seems to have worked. docstore.delete came with an error

Signed-off-by: Kelechi Emeruwa <kelechi@utexas.edu>